### PR TITLE
Update data ingest docs and remove precomputed vector + data matching

### DIFF
--- a/dle/data/management/commands/vectorize.py
+++ b/dle/data/management/commands/vectorize.py
@@ -2,11 +2,8 @@ import asyncio
 import json
 import logging
 from datetime import datetime
-from distutils.util import strtobool
 
 from django.core.management.base import BaseCommand, CommandError
-
-from tqdm import tqdm
 
 from api.apps import ApiConfig
 from data.models import ProductSection
@@ -38,17 +35,6 @@ class Command(BaseCommand):
             type=str,
             help="'TGA', 'FDA', 'EMA', 'HC', or 'all'",
         )
-        parser.add_argument(
-            "--vectorize",
-            type=strtobool,
-            help="Vectorizes existing data for the given agency",
-            default=True,
-        )
-        parser.add_argument(
-            "--vector_file",
-            type=str,
-            help="If a file is passed, insert the existing vectors into Django given existing (unvectorized) agency data",
-        )
 
     @background
     def compute_section_vector_wrapper(self, section):
@@ -58,8 +44,6 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         agency = options["agency"]
-        vectorize = options["vectorize"]
-        vector_filename = options["vector_file"]
 
         if agency not in ["EMA", "FMA", "TGA", "HC", "all"]:
             raise CommandError("'agency' parameter must be an agency")
@@ -67,56 +51,20 @@ class Command(BaseCommand):
         logger.info(self.style.SUCCESS("start vectorizing"))
         logger.info(f"Agency: {agency}")
 
-        # TODO finish and test
-        if vector_filename:
-            """Load the vectors from file to PSQL via Django ORM"""
-            logger.info(f"Opening {vector_filename}")
-            with open(vector_filename, "r") as f:
-                vectors = json.load(f)
-            logger.info("Vectors JSON loaded. Ingesting vectors into Django.")
-            for source_product_id in tqdm(vectors.keys()):
-                versions = vectors[source_product_id]
-                for version in versions.keys():
-                    # logger.info(f"{source_product_id} - {version}")
-                    for section_name in vectors[source_product_id][version]:
-                        # logger.info(f"{source_product_id} - {version} - {section_name}")
-                        vector = json.loads(vectors[source_product_id][version][section_name])
-                        try:
-                            section = ProductSection.objects.get(
-                                section_name=section_name,
-                                label_product__drug_label__source_product_number=source_product_id,
-                                label_product__drug_label__version_date=datetime.strptime(
-                                    version, "%Y/%m/%d"
-                                ),
-                            )
-                            section.bert_vector = vector
-                            section.save()
-                        except ProductSection.DoesNotExist:
-                            logger.error(
-                                f"Could not find ProductSection based on: section_name={section_name}, label_product__drug_label__source_product_number={source_product_id}, and label_product__drug_label__version_date={datetime.strptime(version, '%Y/%m/%d')} "
-                            )
-                        except ProductSection.MultipleObjectsReturned:
-                            logger.error(
-                                f"Found multiple ProductSections based on: section_name={section_name}, label_product__drug_label__source_product_number={source_product_id}, and label_product__drug_label__version_date={datetime.strptime(version, '%Y/%m/%d')} "
-                            )
+        if agency == "all":
+            sections = ProductSection.objects.all()
+        else:
+            sections = ProductSection.objects.filter(label_product__drug_label__source=agency).all()
+        self.total_sections = sections.count()
 
-        if vectorize:
-            if agency == "all":
-                sections = ProductSection.objects.all()
-            else:
-                sections = ProductSection.objects.filter(
-                    label_product__drug_label__source=agency
-                ).all()
-            self.total_sections = sections.count()
+        start = datetime.now()
+        loop = asyncio.get_event_loop()
+        looper = asyncio.gather(*[self.compute_section_vector_wrapper(s) for s in sections])  # type: ignore
+        results = loop.run_until_complete(looper)  # noqa F841
+        end = datetime.now()
+        elapsed = end - start
 
-            start = datetime.now()
-            loop = asyncio.get_event_loop()
-            looper = asyncio.gather(*[self.compute_section_vector_wrapper(s) for s in sections])  # type: ignore
-            results = loop.run_until_complete(looper)  # noqa F841
-            end = datetime.now()
-            elapsed = end - start
-
-            logger.info(
-                f"finished computing vectors ------------- { int(elapsed.total_seconds()) } seconds"
-            )
-            # logger.info(results)
+        logger.info(
+            f"finished computing vectors ------------- { int(elapsed.total_seconds()) } seconds"
+        )
+        # logger.info(results)

--- a/dle/entrypoint
+++ b/dle/entrypoint
@@ -26,9 +26,7 @@ if [[ ($INIT_SUPERUSER) && ("$INIT_SUPERUSER" = "True") ]]; then
   python3 manage.py create_superuser_if_none_exists --user $DJANGO_SUPERUSER_USERNAME --email $DJANGO_SUPERUSER_EMAIL --password $DJANGO_SUPERUSER_PASSWORD
 fi
 
-# Recommended way to bootstrap project is with a PSQL dump; fixtures can cause RAM issues,
-# and matching pre-computed vectors to existing scraped data does not work well.
-# Otherwise, set $LOAD and $VECTORIZE to true but this may take a very long time to execute.
+# Recommended way to bootstrap project is with a PSQL dump; fixtures can cause RAM issues.
 if [[ ($LOAD_PSQL_DUMP) && ("$LOAD_PSQL_DUMP" = "True") ]]; then
   echo "Loading PSQL dump"
   # TODO load PSQL dump from /app/media/psql.dump
@@ -45,30 +43,7 @@ if [[ ($LOAD_FIXTURES) && ("$LOAD_FIXTURES" = "True") ]]; then
   echo "Finished loading fixtures"
 fi
 
-# Loading pre-computed vectors (not recommended)
-# This was an attempt to speed up the vectorization process, as vectorization is slow within container.
-# However, using fixtures seems to be better because it's hard to get a good composite structure
-# for the vectors JSON file - composite key of drug ID + agency + version_date.
-if [[ ($LOAD_FDA_VECTORS) && ("$LOAD_FDA_VECTORS" = "True")]]; then
-  # You must have pre-vectorized texts and placed the appropriate JSON file in /media
-  echo "Starting to load FDA vectors into Django"
-  python3 manage.py vectorize --elasticingest False --agency FDA --vector_file "/app/media/fda_vectors.json"
-  echo "FDA vectors loaded!"
-fi
-if [[ ($LOAD_TGA_VECTORS) && ("$LOAD_TGA_VECTORS" = "True")]]; then
-  # You must have pre-vectorized texts and placed the appropriate JSON file in /media
-  echo "Starting to load TGA vectors into Django"
-  python3 manage.py vectorize --elasticingest False --agency TGA --vector_file "/app/media/tga_vectors.json"
-  echo "TGA vectors loaded!"
-fi
-if [[ ($LOAD_EMA_VECTORS) && ("$LOAD_EMA_VECTORS" = "True")]]; then
-  # You must have pre-vectorized texts and placed the appropriate JSON file in /media
-  echo "Starting to load FDA vectors into Django"
-  python3 manage.py vectorize --elasticingest False --agency EMA --vector_file "/app/media/ema_vectors.json"
-  echo "EMA vectors loaded!"
-fi
-
-# Otherwise, if not loading fixtures or pre-computed vectors, or using a PSQL dump,
+# Otherwise, if not loading fixtures or or using a PSQL dump,
 # you can run a scrape for new data and then vectorize it. This will take a long time
 if [[ ($LOAD) && ("$LOAD" = "True") ]]; then
   echo "Beginning the Django data ingest"

--- a/dle/entrypoint
+++ b/dle/entrypoint
@@ -26,6 +26,16 @@ if [[ ($INIT_SUPERUSER) && ("$INIT_SUPERUSER" = "True") ]]; then
   python3 manage.py create_superuser_if_none_exists --user $DJANGO_SUPERUSER_USERNAME --email $DJANGO_SUPERUSER_EMAIL --password $DJANGO_SUPERUSER_PASSWORD
 fi
 
+# Recommended way to bootstrap project is with a PSQL dump; fixtures can cause RAM issues,
+# and matching pre-computed vectors to existing scraped data does not work well.
+# Otherwise, set $LOAD and $VECTORIZE to true but this may take a very long time to execute.
+if [[ ($LOAD_PSQL_DUMP) && ("$LOAD_PSQL_DUMP" = "True") ]]; then
+  echo "Loading PSQL dump"
+  # TODO load PSQL dump from /app/media/psql.dump
+  # PSQL dump should be in -fc format (custom format, compressed)
+  psql -U $POSTGRES_USER -d $POSTGRES_DB -f /app/media/psql.dump
+  echo "Finished loading PSQL dump"
+fi
 
 # Load fixtures, a JSON file containing the data for the database
 # Place the JSON file in /app/data/fixtures (from S3 unless we switch to Git LFS)
@@ -35,31 +45,7 @@ if [[ ($LOAD_FIXTURES) && ("$LOAD_FIXTURES" = "True") ]]; then
   echo "Finished loading fixtures"
 fi
 
-
-# Otherwise, if not loading fixtures, you can run a scrape for new data
-# This will take a long time
-if [[ ($LOAD) && ("$LOAD" = "True") ]]; then
-  echo "Beginning the Django data ingest"
-  echo "Loading EMA (EU) data"
-  python3 manage.py load_ema_data --type full
-  echo "Finished loading EMA (EU) data"
-  echo "Loading FDA (US) data"
-  python3 manage.py load_fda_data --type full
-  echo "Finished loading FDA (US) data"
-  echo "Loading TGA (Australia) data"
-  python3 manage.py load_tga_data --type full
-  echo "Finished loading TGA (Australia) data"
-  echo "Updating latest drug labels"
-  echo "Loading HC (Health Canada) data"
-  python3 manage.py load_hc_data --type full
-  echo "Finished loading HC (Health Canada) data"
-  python3 manage.py update_latest_drug_labels
-  echo "Finished updating latest drug labels"
-  echo "Ended the Django data ingest"
-fi
-
-
-# Loading pre-computed vectors
+# Loading pre-computed vectors (not recommended)
 # This was an attempt to speed up the vectorization process, as vectorization is slow within container.
 # However, using fixtures seems to be better because it's hard to get a good composite structure
 # for the vectors JSON file - composite key of drug ID + agency + version_date.
@@ -80,6 +66,34 @@ if [[ ($LOAD_EMA_VECTORS) && ("$LOAD_EMA_VECTORS" = "True")]]; then
   echo "Starting to load FDA vectors into Django"
   python3 manage.py vectorize --elasticingest False --agency EMA --vector_file "/app/media/ema_vectors.json"
   echo "EMA vectors loaded!"
+fi
+
+# Otherwise, if not loading fixtures or pre-computed vectors, or using a PSQL dump,
+# you can run a scrape for new data and then vectorize it. This will take a long time
+if [[ ($LOAD) && ("$LOAD" = "True") ]]; then
+  echo "Beginning the Django data ingest"
+  echo "Loading EMA (EU) data"
+  python3 manage.py load_ema_data --type full
+  echo "Finished loading EMA (EU) data"
+  echo "Loading FDA (US) data"
+  python3 manage.py load_fda_data --type full
+  echo "Finished loading FDA (US) data"
+  echo "Loading TGA (Australia) data"
+  python3 manage.py load_tga_data --type full
+  echo "Finished loading TGA (Australia) data"
+  echo "Updating latest drug labels"
+  echo "Loading HC (Health Canada) data"
+  python3 manage.py load_hc_data --type full
+  echo "Finished loading HC (Health Canada) data"
+  python3 manage.py update_latest_drug_labels
+  echo "Finished updating latest drug labels"
+  echo "Ended the Django data ingest"
+
+  if [[ ($VECTORIZE) && ("$VECTORIZE" = "True") ]]; then
+    echo "Starting to vectorize the data"
+    python3 manage.py vectorize --agency all
+    echo "Finished vectorizing the data"
+  fi
 fi
 
 

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -33,27 +33,44 @@ The project is containerized so that it can be run locally or deployed to a clou
 
 4. Run `docker compose up` to start the application. This will take a long time the first time. Steps that occur:
     - Builds the Django container from `Dockerfile.dev`
-        - `python:3.10.10-slim-buster` base image
+        - `python:3.11-slim-buster` base image
         - Installs some system dependencies
         - Installs Python dependencies from `requirements.txt`
-        - Does not copy the source code into the container - instead, mounts the source code as a volume so you can make changes on your local machine and have them reflected in the container
+        - Does not copy the source code into the container - instead, mounts the source code as a volume so you can make changes on your local machine and have them reflected in the container. For ECS deploys, code is copied into the container.
     - Pulls Postgres 14 image
-    - Pulls Elasticsearch 8 image and Kibana image, which are used for the `es01` (only running 1 node for now), `elastic-setup`, and `kibana` services
-    - Starts all the services, which provisions Elasticsearch and Kibana
+    - Pulls Elasticsearch 8.x (currently 8.7) image and Kibana image, which are used for the `es01` (only running 1 node for now), `elastic-setup`, and `kibana` services
+    - Starts all the services, which provisions Elasticsearch and Kibana (not with our schema yet)
     - Runs Django entrypoint script
         - Waits for Postgres connection to succeed
         - Runs Django migrations if `MIGRATE` is set to `True`
         - Collects static files if `MIGRATE` is set to `True` (possibly have another env variable for this?)
-        - Creates a superuser if `INIT_SUPERUSER` is set to `True` and `SUPERUSER_USERNAME` and `SUPERUSER_PASSWORD` are set
-        - Loads data if `LOAD` is set to `True`
-            - This step takes a long time
-            - Runs FDA (currently DailyMed, soon OpenFDA), EMA, TGA, and HC data loaders (`load_<agency>_data --type full`)
-            - Runs `update_latest_drug_labels`
-        - Potentially loads pre-computed vectors from `/app/media/<vector>.json` files, but this functionality doesn't work well because of misses on nested composite keys (`DrugLabel.source_product_number` + `dl.version_date` + `section_name`)
-        - Instead, data should get loaded from a fixture (possible RAM issue as they are big) or a PSQL dump
-        - Possibly provisions Elasticsearch with the `productsection` index and mappings
-        - Possibly loads data from Django into Elasticsearch
-        - Runs a local dev webserver, or Nginx + Gunicorn, for Django on port 8000
+        - Creates a superuser if `INIT_SUPERUSER` is set to `True` and `SUPERUSER_USERNAME` and `SUPERUSER_PASSWORD` are set. This uses a custom command so it doesn't fail if the user already exists.
+        - Loads data:
+            - There are multiple options to get data loaded. Data needs to exist both in Django and Elasticsearch; it is first loaded into Django, then indexed into Elasticsearch. Data needs to both be scraped and parsed from agency websites, XML files, or PDFs and then vectorized. The following options are mutually exclusive (no need to load data from multiple sources)
+            - Option 1: create the data yourself
+                - Set `LOAD` to `True` and `VECTORIZE` to `True`
+                - This takes the longest but generates data from scratch. Probably a couple of days total. Estimated scraping time:
+                    - EMA:
+                    - TGA:
+                    - OpenFDA:
+                    - HC:
+                - Estimated vectorization time:
+                - You can also not set `LOAD` to `True`, and instead run `load_<agency>_data` commands manually to scrape just one agency. Make sure to run `update_latest_drug_labels` as well.
+            - Option 2: load data from a fixture
+                - Set `LOAD_FIXTURES` to `True` and place the appropriate fixture files in `/app/data/fixtures`. These are in the S3 bucket.
+                - This is fairly fast and does not wipe your local database the same way that loading a `PSQL` dump does, but it does potentially use a lot of RAM. Estimated time: 
+            - Option 3: load data from a PSQL dump. This is the fastest option but it will wipe your local database.
+                - Obtain a PSQL dump from the S3 bucket and place it in `/app/media/psql.dump`
+                - Set `LOAD_PSQL_DUMP` to `True`
+                - Loads both data and vectors. Estimated time:
+        - Ingest data from Django into Elasticsearch
+            - Set `PROVISION_ES` to `True` to provision Elasticsearch with the `productsection` index and mappings
+            - Uses the mapping file at `search/mappings/provision.json` to create the index with our schema
+            - Then ingests all the agency data from Django to Elasticsearch
+            - Estimted time: 
+        - Runs a webserver for Django
+            - Set `USE_NGINX` to `True` for production deployments with Nginx + Gunicorn
+            - Otherwise uses Django's built-in `runserver` command on port `8000`
 
 5. Services:
     - Django: http://localhost:8000
@@ -63,8 +80,13 @@ The project is containerized so that it can be run locally or deployed to a clou
         - otherwise you can use `--cacert` to specify a certificate - copy it from container to your local machine with `docker cp <containerId>:/usr/share/elasticsearch/config/certs/ca/ca.crt .`)
         - or use Kibana console to interact with Elasticsearch instead
     - Kibana: http://localhost:5601
+    - Postgres: http://localhost:5432
+        - Exec into the container with `docker compose exec postgres bash`
+        - Enter the PSQL CLI with `psql -U postgres`
 
-6. Manually create Elasticsearch index and mappings
+#### Optional or manual steps
+
+- We used to manually create Elasticsearch index and mappings
     - Create ES index
         - The `elasticsearch-django` library supposedly has a CLI command to do this but I have not been able to get it to work (`python3 manage.py create_search_index <INDEX_NAME>`)
         - Instead I have been using Kibana console to create indices
@@ -145,10 +167,10 @@ The project is containerized so that it can be run locally or deployed to a clou
     - Make sure your mappings look good and the `text_embedding` mapping in particular is of type `dense_vector`
         - Run `GET /productsection/_mapping` to see your index schema
 
-7. Manually load vector data into Postgres and Elasticsearch
-    - Either create your own vectors, or download existing vector JSON from S3
-        - If using pre-computed vectors, you will need to make sure that `version_date` of those vectors matches the `version_date` of your Postgres / Django `DrugLabel` objects. You may need to use the Django ORM to modify the version date - this is at least the case for EMA labels currently. Peter's EMA fix may have resolved this but haven't tried re-ingesting EMA labels or re-creating EMA vectors after that fix.
-        - If creating vectors, check out the `docs/section_mapping/vectorize.ipynb` notebook. You should use `django_extensions` to run the notebooks with the Django context, but on your local machine rather than within Docker. YMMV but it seems that for some reason vectorization is agonizingly slow within Docker.
+- We used to more manually load vector data into Postgres and Elasticsearch
+    - Either create your own vectors, or download existing pre-computed vectors (JSON) from S3
+        - If using pre-computed vectors, you will need to make sure that `version_date` of those vectors matches the `version_date` of your Postgres / Django `DrugLabel` objects. You may need to use the Django ORM to modify the version date - this is at least the case for EMA labels currently. Peter's EMA fix may have resolved this but haven't tried re-ingesting EMA labels or re-creating EMA vectors after that fix. This is pretty brittle and didn't work well because of misses on nested composite keys (`DrugLabel.source_product_number` + `dl.version_date` + `section_name`).
+        - If creating vectors, check out the `docs/section_mapping/vectorize.ipynb` notebook. You should use `django_extensions` to run the notebooks with the Django context, but on your local machine rather than within Docker. YMMV but it seems that for some reason vectorization is agonizingly slow within Docker for Mac.
     - Place the vectors into `media` folder.
     - Exec into the Django container - from `dle`, `docker compose exec django bash`
     - Run the management command to ingest: `python3 manage.py vectorize --elasticingest True --vector_file "ema_vectors.json" --agency EMA`
@@ -158,4 +180,4 @@ The project is containerized so that it can be run locally or deployed to a clou
 
 ## Deployment
 
-### Architecture
+### AWS Architecture


### PR DESCRIPTION
Matching pre-computed vectors to existing Django data did not work well. Removing. You can either load PSQL dump, scrape agencies + compute vectors (too slow within Docker for Mac - use script from outside container; inside Docker seems fine on EC2), or load fixtures (slower than PSQL and possible RAM issue).