### PR TITLE
Hides duplicate sections when multiple sections for same label in search results DL-196

### DIFF
--- a/dle/search/static/search/es_search.js
+++ b/dle/search/static/search/es_search.js
@@ -265,6 +265,13 @@ search.addWidgets([
                 } else {
                     singleItemUrl = `../data/single_label_view/${hit.drug_label_id}, ${globalSearchTerm}`;
                 }
+
+                if (foundDrugLabels.includes(hit.drug_label_id)) {
+                return html``;
+                } 
+
+                foundDrugLabels.push(hit.drug_label_id);                
+
                 return html `
                       <input type="checkbox" name="compare" value="${hit.drug_label_id}" />
                       <a href="${singleItemUrl}"style='font-weight:bold'>${components.Highlight({ attribute: 'drug_label_product_name', hit })}</a> <br />


### PR DESCRIPTION
Turns out the logic must have been removed in fixing a merge conflict. Added back in. 

<img width="1356" alt="Screenshot 2023-04-27 at 4 59 38 PM" src="https://user-images.githubusercontent.com/310231/235000767-72ffd51f-d824-4967-8f92-d344e1c5b2f0.png">


Commit message below
Puts back in logic for only showing 1 label when more return in resul…ts for multiple sections of same drug label