### PR TITLE
Tweaks display of drug match search logic DL-202

### DIFF
--- a/dle/data/templates/data/_label_search_results.html
+++ b/dle/data/templates/data/_label_search_results.html
@@ -1,12 +1,10 @@
 {% for dl in labels %}
-    <div class="drug-label">
-        <h2>{{ dl.product_name }}</h2>
-        <h3>{{ dl.generic_name}}</h3>
-        <p>{{ dl.source_product_number }}</p>
-        <p>{{ dl.label_source }}</p>
-        <p>{{ dl.marketer }}</p>
-        <p>{{ dl.link }}</p>
-        <p>{{ dl.version_date }}</p>
-        <p>{{ dl.updated_at }}</p>
-    </div>
+    {% if forloop.counter0 == 0 %}
+        <div class="drug-label">
+            <h2>{{ dl.product_name }}</h2>
+    {% endif %}
+    <p><a href="../data/single_label_view/{{ dl.id }}">{{dl.product_name}} <i>{{dl.source}}</i> {{dl.version_date}} <i>{{dl.marketer}}</i></a></p>
+    {% if forloop.last %}
+        </div>
+    {% endif %}
 {% endfor %}

--- a/dle/search/static/search/styles.css
+++ b/dle/search/static/search/styles.css
@@ -128,3 +128,14 @@ ul.nav li {
   .ais-Hits-item:empty{ 
     display: none;
   }
+
+  .drug-label {
+    border: 2px solid #000;
+    padding: 10px;
+    width: 65%;
+    margin-bottom: 25px;
+  }
+
+  .drug-label:empty{
+    display: none;
+  }


### PR DESCRIPTION
Gets the Drug product name match working as expected (not generic as David mentioned). Tweaked the logic to show all specific versions so user can go quickly view each and go to their respective pages easily. 

Tried to make it a little more distinct than the other. @lucyzsunshine Feel free to make design tweaks as needed. 

<img width="1379" alt="Screenshot 2023-04-27 at 6 13 35 PM" src="https://user-images.githubusercontent.com/310231/235010601-1406a3d2-c599-4391-94eb-636d74d426e1.png">


Commit message:
Gets display of drug label find search working as expected and slightly styled