### PR TITLE
Fixes query for exact match drug label search DL-223

### DIFF
--- a/dle/data/templates/data/_label_search_results.html
+++ b/dle/data/templates/data/_label_search_results.html
@@ -1,8 +1,7 @@
 {% for dl in labels %}
     {% if forloop.counter0 == 0 %}
         <div class="drug-label">
-            <h2>{{ dl.product_name }}</h2>
-            <h2>{{ dl.generic_name}}</h2>
+            <h2>{{ dl.product_name }} Labels</h2>
     {% endif %}
     <p>
         <input type="checkbox" name="compare" value="{{dl.id}}" />

--- a/dle/data/views.py
+++ b/dle/data/views.py
@@ -1,5 +1,4 @@
 from django.core.exceptions import ObjectDoesNotExist
-from django.db.models import Q
 from django.http import HttpRequest, HttpResponse
 from django.shortcuts import get_object_or_404, render
 from django.views.decorators.http import require_GET
@@ -92,9 +91,7 @@ def search_label_htmx(request: HtmxHttpRequest) -> HttpResponse:
     if request.htmx:
         q = request.GET.get("query", "")
         if q:
-            labels = DrugLabel.objects.filter(
-                Q(product_name__icontains=q) | Q(generic_name__icontains=q)
-            )
+            labels = DrugLabel.objects.filter(product_name__iexact=q).order_by("version_date")[:10]
 
         else:
             print("No query string")


### PR DESCRIPTION
We were using a substring search previously for generic name plus product name. This changes to use an exact string match between the product name only as discussed with David.

<img width="855" alt="Screenshot 2023-05-02 at 10 51 10 AM" src="https://user-images.githubusercontent.com/310231/235745290-e4091f14-4f94-4fce-84c7-e70c9a86a433.png">


DL-223