### PR TITLE
Fixes slow loading issue on javascript side when no search term and >100k results DL-226

### DIFF
--- a/dle/search/static/search/es_search.js
+++ b/dle/search/static/search/es_search.js
@@ -3,7 +3,12 @@
 // See below - need to figure out how to disable caching
 // import { createNullCache } from 'https://cdn.jsdelivr.net/npm/@algolia/cache-common/+esm';
 
-var globalSearchTerm = '';
+const queryString = window.location.search;
+const urlParams = new URLSearchParams(queryString);
+var globalSearchTerm =  urlParams.get('productsection[query]') || '';
+// above is code to make sure we're getting the search term on a first page
+// load after coming from the home page
+
 var queryType = 'match'; // knn, simpleQueryString, match
 var searchkit_ready = false;
 
@@ -267,7 +272,7 @@ search.addWidgets([
                 }
 
 
-                if (globalSearchTerm.lengh > 4) {
+                if (globalSearchTerm.length > 4) {
                     // do to scaling issues, we only want to do this potentially costly check
                     // of which drug labels are in the array of there's enough categories to
                     // have a legitimate search and not using filtering methods.

--- a/dle/search/static/search/es_search.js
+++ b/dle/search/static/search/es_search.js
@@ -266,11 +266,17 @@ search.addWidgets([
                     singleItemUrl = `../data/single_label_view/${hit.drug_label_id}, ${globalSearchTerm}`;
                 }
 
-                if (foundDrugLabels.includes(hit.drug_label_id)) {
-                return html``;
-                } 
 
-                foundDrugLabels.push(hit.drug_label_id);                
+                if (globalSearchTerm.lengh > 4) {
+                    // do to scaling issues, we only want to do this potentially costly check
+                    // of which drug labels are in the array of there's enough categories to
+                    // have a legitimate search and not using filtering methods.
+                    if (foundDrugLabels.includes(hit.drug_label_id)) {
+                        return html``;
+                    }
+
+                    foundDrugLabels.push(hit.drug_label_id);
+                }
 
                 return html `
                       <input type="checkbox" name="compare" value="${hit.drug_label_id}" />


### PR DESCRIPTION
Adds logic to only do the intensive array insertions/checking if there's a legitimate search query.

Also adds logic to get the globalSearchQuery correct on first page load on search page coming from homepage.