### PR TITLE
Properly closes table row tag

### DIFF
--- a/dle/compare/templates/compare/compare_versions.html
+++ b/dle/compare/templates/compare/compare_versions.html
@@ -31,7 +31,6 @@
                     </dl>
                 </td>
             <tr>
-            <tr>
                 <td class="section-td">
                     <dl>
                         <dt>Product Name: <a href="{% url 'data:single_label_view' drug_label_id=dl2.id %}">{{ dl2.product_name|title }}</a></dt>

--- a/dle/compare/templates/compare/compare_versions.html
+++ b/dle/compare/templates/compare/compare_versions.html
@@ -30,6 +30,7 @@
                         <dt>Source: {{ dl1.source }}</dt>
                     </dl>
                 </td>
+            </tr>
             <tr>
                 <td class="section-td">
                     <dl>


### PR DESCRIPTION
Saw this when taking a look at the previously merged PR. The bug probably doesn't cause a problem in most browsers. 